### PR TITLE
set @typescript-eslint/explicit-module-boundary-types rule off

### DIFF
--- a/index.js
+++ b/index.js
@@ -23,5 +23,6 @@ module.exports = {
     ],
     rules: {
         "react/prop-types": "off",
+        '@typescript-eslint/explicit-module-boundary-types': ['off'],
     },
 };


### PR DESCRIPTION
Remove warning for explicit function return types. This warning most often is unnecessary with typescript, as the type inference is good enough to display the type.