### PR TITLE
Fix steamline tags for CI

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   publish: 
-    runs-on: self-hosted
+    runs-on: default
     steps:
       - uses: actions/checkout@v2
       

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -6,6 +6,7 @@ on:
 
 jobs:
   publish: 
+    runs-on: self-hosted
     steps:
       - uses: actions/checkout@v2
       


### PR DESCRIPTION
Due to a mistaken understanding of what runs-on actually would do if removed we have managed to break our pipelines by removing the runs-on: default. This PR reverts the changes to remove runs-on: default and runs-on: self-hosted and makes sure that we only use runs-on: default.